### PR TITLE
s6: add missing /usr/sbin/s6* binaries

### DIFF
--- a/s6-2.0.1.0/debian/s6.install.in
+++ b/s6-2.0.1.0/debian/s6.install.in
@@ -1,3 +1,4 @@
 usr/lib/libs6*.so.*
 usr/bin/s6*
+usr/sbin/s6*
 usr/lib/@DEB_HOST_MULTIARCH@/s6*


### PR DESCRIPTION
This is also included in #1 
